### PR TITLE
Properly capturing everything after #

### DIFF
--- a/syntaxes/rules.tmLanguage.json
+++ b/syntaxes/rules.tmLanguage.json
@@ -109,7 +109,7 @@
                         "name": "punctuation.definition.comment.rules"
                     }
                 },
-                "match": "#",
+                "match": "#.*",
                 "name": "comment.block.empty.rules"
             }]
         },


### PR DESCRIPTION
Only the '#' was set as a comment. Now everything after it is a comment.